### PR TITLE
feat: support 'jpg' extension

### DIFF
--- a/src/imgur/constants.ts
+++ b/src/imgur/constants.ts
@@ -13,4 +13,5 @@ export const IMGUR_POTENTIALLY_SUPPORTED_FILES_EXTENSIONS = [
   'webm',
   'mov',
   'mkv',
+  'jpg',
 ]

--- a/src/imgur/constants.ts
+++ b/src/imgur/constants.ts
@@ -3,6 +3,7 @@ export const IMGUR_ACCESS_TOKEN_LOCALSTORAGE_KEY = 'imgur-access_token'
 
 export const IMGUR_POTENTIALLY_SUPPORTED_FILES_EXTENSIONS = [
   'jpeg',
+  'jpg',
   'png',
   'gif',
   'apng',
@@ -13,5 +14,4 @@ export const IMGUR_POTENTIALLY_SUPPORTED_FILES_EXTENSIONS = [
   'webm',
   'mov',
   'mkv',
-  'jpg',
 ]


### PR DESCRIPTION
Imgur seems to support uploading _jpg_ format images as well. It is the format my phone uses, and I use this plugin a lot in order to not consume the limited storage I've got.
I've tested this change locally and I haven't come across any issues regarding it.
Thank you!